### PR TITLE
Coquille

### DIFF
--- a/stations-meteo.Rmd
+++ b/stations-meteo.Rmd
@@ -20,7 +20,7 @@ library(dgfr)
   plot_stations_meteo()
 ```
 
-## Station météo de Purpon
+## Station météo de Purpan
 
 * [Données sources](https://www.data.gouv.fr/fr/datasets/5d31439806e3e77d64e75019/#_)
 


### PR DESCRIPTION
Correction d'une petite coquille dans le nom d'une station météo.